### PR TITLE
Build environment setup and Next.js build

### DIFF
--- a/web/scripts/deploy-setup.ts
+++ b/web/scripts/deploy-setup.ts
@@ -74,7 +74,7 @@ async function main() {
           frequency: 'DAILY',
           isRequired: true,
           reward: 1.00,
-          scheduledDays: [1, 2, 3, 4, 5], // Monday-Friday
+          scheduledDays: JSON.stringify([1, 2, 3, 4, 5]), // Monday-Friday
           scheduledTime: '08:00',
           estimatedMinutes: 5,
         },
@@ -86,7 +86,7 @@ async function main() {
           frequency: 'WEEKLY',
           isRequired: false,
           reward: 3.00,
-          scheduledDays: [1], // Monday
+          scheduledDays: JSON.stringify([1]), // Monday
           scheduledTime: '19:00',
           estimatedMinutes: 10,
         },
@@ -98,7 +98,7 @@ async function main() {
           frequency: 'WEEKLY',
           isRequired: false,
           reward: 5.00,
-          scheduledDays: [6], // Saturday
+          scheduledDays: JSON.stringify([6]), // Saturday
           estimatedMinutes: 30,
         }
       ]


### PR DESCRIPTION
Fix TypeScript error by converting `scheduledDays` array to JSON string.

The Prisma schema defines `scheduledDays` as a `String?` type, expecting a JSON string. The previous code was assigning a `number[]`, leading to a type mismatch and build failure.