### PR TITLE
Fix chore completion state persistence

### DIFF
--- a/web/src/app/api/dashboard/child/route.ts
+++ b/web/src/app/api/dashboard/child/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (session.user.role !== 'CHILD') {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 })
+    }
+
+    // Get user's family
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { familyId: true }
+    })
+
+    if (!user?.familyId) {
+      return NextResponse.json({ error: 'User has no family' }, { status: 400 })
+    }
+
+    // Get current week's date range
+    const now = new Date()
+    const weekStart = new Date(now)
+    weekStart.setDate(now.getDate() - now.getDay())
+    weekStart.setHours(0, 0, 0, 0)
+
+    const weekEnd = new Date(weekStart)
+    weekEnd.setDate(weekEnd.getDate() + 6)
+    weekEnd.setHours(23, 59, 59, 999)
+
+    // Get user's chore submissions for this week
+    const submissions = await prisma.choreSubmission.findMany({
+      where: {
+        userId: session.user.id,
+        submittedAt: {
+          gte: weekStart,
+          lte: weekEnd
+        }
+      },
+      include: {
+        assignment: {
+          include: {
+            chore: {
+              select: {
+                id: true,
+                title: true,
+                reward: true
+              }
+            }
+          }
+        },
+        approval: {
+          select: {
+            approved: true,
+            feedback: true,
+            score: true,
+            partialReward: true,
+            approvedAt: true
+          }
+        }
+      },
+      orderBy: { submittedAt: 'desc' }
+    })
+
+    // Get assigned chores for the current week
+    const assignments = await prisma.choreAssignment.findMany({
+      where: {
+        userId: session.user.id,
+        familyId: user.familyId,
+        weekStart: {
+          lte: now
+        }
+      },
+      include: {
+        chore: {
+          select: {
+            id: true,
+            title: true,
+            description: true,
+            reward: true,
+            estimatedMinutes: true,
+            isRequired: true,
+            frequency: true,
+            type: true
+          }
+        }
+      },
+      orderBy: { weekStart: 'desc' }
+    })
+
+    // Format submissions with necessary data
+    const formattedSubmissions = submissions.map(submission => ({
+      id: submission.id,
+      choreId: submission.assignment.chore.id,
+      choreName: submission.assignment.chore.title,
+      reward: submission.assignment.chore.reward,
+      status: submission.status,
+      submittedAt: submission.submittedAt,
+      completedAt: submission.completedAt,
+      notes: submission.notes,
+      approval: submission.approval ? {
+        approved: submission.approval.approved,
+        feedback: submission.approval.feedback,
+        score: submission.approval.score,
+        partialReward: submission.approval.partialReward,
+        approvedAt: submission.approval.approvedAt
+      } : null
+    }))
+
+    // Format assigned chores
+    const formattedChores = assignments.map(assignment => ({
+      id: assignment.chore.id,
+      title: assignment.chore.title,
+      description: assignment.chore.description,
+      reward: assignment.chore.reward,
+      estimatedMinutes: assignment.chore.estimatedMinutes,
+      isRequired: assignment.chore.isRequired,
+      frequency: assignment.chore.frequency,
+      type: assignment.chore.type,
+      assignmentId: assignment.id,
+      weekStart: assignment.weekStart
+    }))
+
+    // Calculate weekly stats
+    const approvedSubmissions = submissions.filter(s => 
+      s.status === 'APPROVED' || s.status === 'AUTO_APPROVED'
+    )
+    const totalEarnings = approvedSubmissions.reduce((sum, s) => 
+      sum + (s.approval?.partialReward || s.assignment.chore.reward || 0), 0
+    )
+    const completedCount = approvedSubmissions.length
+    const totalAssigned = assignments.length
+    const completionRate = totalAssigned > 0 ? Math.round((completedCount / totalAssigned) * 100) : 0
+
+    const dashboardData = {
+      user: {
+        id: session.user.id,
+        name: session.user.name,
+        role: session.user.role
+      },
+      submissions: formattedSubmissions,
+      assignedChores: formattedChores,
+      weeklyStats: {
+        totalEarnings,
+        completedCount,
+        totalAssigned,
+        completionRate,
+        pendingCount: submissions.filter(s => s.status === 'PENDING').length
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: dashboardData
+    })
+
+  } catch (error) {
+    console.error('Child dashboard API error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch dashboard data', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement actual chore submission and status tracking in the child dashboard to persist data and reflect correctly in parent view.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation of `handleChoreSubmit` in the child dashboard only updated local UI state, meaning chore submissions were not saved to the database. This PR replaces the mock logic with real API calls to `/api/chore-submissions` and introduces a new `/api/dashboard/child` endpoint to fetch persistent submission statuses, ensuring data integrity and proper display for parents.

---

[Open in Web](https://cursor.com/agents?id=bc-ce895e24-8d2a-4521-b3ad-840280f53245) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ce895e24-8d2a-4521-b3ad-840280f53245) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)