### PR TITLE
Add missing feedback and events sections

### DIFF
--- a/web/src/app/api/important-events/route.ts
+++ b/web/src/app/api/important-events/route.ts
@@ -69,10 +69,17 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       events: eventsWithCountdown
     })
+    
+    // Prevent PWA caching
+    response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
 
   } catch (error) {
     console.error('Important events fetch error:', error)

--- a/web/src/app/api/parental-feedback/route.ts
+++ b/web/src/app/api/parental-feedback/route.ts
@@ -103,11 +103,18 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       feedback,
       todaysSummary: todaysFeedback
     })
+    
+    // Prevent PWA caching
+    response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+    response.headers.set('Pragma', 'no-cache')
+    response.headers.set('Expires', '0')
+    
+    return response
 
   } catch (error) {
     console.error('Parental feedback fetch error:', error)

--- a/web/src/app/dashboard/child/page.tsx
+++ b/web/src/app/dashboard/child/page.tsx
@@ -75,7 +75,14 @@ export default function ChildDashboard() {
 
   const fetchUpcomingEvents = async () => {
     try {
-      const response = await fetch('/api/important-events?upcoming=true&limit=3')
+      const response = await fetch('/api/important-events?upcoming=true&limit=3', {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
       if (response.ok) {
         const result = await response.json()
         setUpcomingEvents(result.events || [])

--- a/web/src/app/dashboard/parent/page.tsx
+++ b/web/src/app/dashboard/parent/page.tsx
@@ -100,7 +100,16 @@ export default function ParentDashboard() {
 
   const fetchParentalFeedback = async () => {
     try {
-      const response = await fetch('/api/parental-feedback?limit=10')
+      // Add timestamp to prevent PWA caching
+      const timestamp = new Date().getTime()
+      const response = await fetch(`/api/parental-feedback?limit=10&_t=${timestamp}`, {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
       if (response.ok) {
         const result = await response.json()
         setParentalFeedback(result.feedback || [])
@@ -113,7 +122,14 @@ export default function ParentDashboard() {
 
   const fetchImportantEvents = async () => {
     try {
-      const response = await fetch('/api/important-events?upcoming=true&limit=5')
+      const response = await fetch('/api/important-events?upcoming=true&limit=5', {
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0'
+        }
+      })
       if (response.ok) {
         const result = await response.json()
         setImportantEvents(result.events || [])

--- a/web/src/lib/pwa-utils.ts
+++ b/web/src/lib/pwa-utils.ts
@@ -1,0 +1,50 @@
+// PWA utility functions to handle caching issues
+
+/**
+ * Detect if the app is running in PWA standalone mode
+ */
+export function isPWAMode(): boolean {
+  if (typeof window === 'undefined') return false
+  
+  // Check if running in standalone mode (PWA)
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as any).standalone === true ||
+    document.referrer.includes('android-app://')
+  )
+}
+
+/**
+ * Get fetch options with cache busting for PWA
+ */
+export function getPWAFetchOptions(): RequestInit {
+  const timestamp = new Date().getTime()
+  return {
+    cache: 'no-store' as RequestCache,
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Pragma': 'no-cache',
+      'Expires': '0',
+      'X-Timestamp': timestamp.toString()
+    }
+  }
+}
+
+/**
+ * Create a cache-busted URL for PWA
+ */
+export function getCacheBustedUrl(url: string): string {
+  const separator = url.includes('?') ? '&' : '?'
+  const timestamp = new Date().getTime()
+  return `${url}${separator}_t=${timestamp}`
+}
+
+/**
+ * Force reload sections that might be cached in PWA
+ */
+export function forceReloadPWAData() {
+  if (isPWAMode()) {
+    // Trigger a custom event that components can listen to
+    window.dispatchEvent(new CustomEvent('pwa-force-reload'))
+  }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add cache control headers to API fetches and responses to resolve missing dashboard sections in PWA.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The 'feedback' and 'upcoming events' sections were not visible when the application was accessed via a PWA saved session, due to aggressive caching. This change ensures that API calls for these sections always fetch fresh data, making them visible in PWA mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddced632-14b5-4321-a4b7-e3d653e58799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ddced632-14b5-4321-a4b7-e3d653e58799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>