### PR TITLE
Fix: Resolve Prisma client initialization and build failures

### DIFF
--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider      = "prisma-client-js"
-  output        = "../src/generated/prisma"
   binaryTargets = ["native", "rhel-openssl-1.0.x"]
 }
 

--- a/web/scripts/diagnose-dashboard-issue.ts
+++ b/web/scripts/diagnose-dashboard-issue.ts
@@ -5,9 +5,10 @@
  * This script helps identify and fix common problems with the dashboard
  */
 
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 
 const prisma = new PrismaClient()
+const Decimal = Prisma.Decimal
 
 async function diagnoseDashboardIssue() {
   console.log('🔍 Diagnosing dashboard data issues...\n')
@@ -138,8 +139,8 @@ async function diagnoseDashboardIssue() {
       })
 
       console.log('   Chores found:')
-      chores.forEach((chore: { title: string; reward: number; family: { name: string } }) => {
-        console.log(`   - "${chore.title}" in ${chore.family.name} ($${chore.reward})`)
+      chores.forEach((chore: { title: string; reward: Prisma.Decimal; family: { name: string } }) => {
+        console.log(`   - "${chore.title}" in ${chore.family.name} ($${chore.reward.toNumber()})`)
       })
     }
     console.log()

--- a/web/src/app/api/auth/accept-invitation/route.ts
+++ b/web/src/app/api/auth/accept-invitation/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Create family membership for the user
-    await prisma.$transaction(async (tx: typeof prisma) => {
+    await prisma.$transaction(async (tx) => {
       // Create family membership
       await tx.familyMembership.create({
         data: {

--- a/web/src/app/api/auth/register-with-invitation/route.ts
+++ b/web/src/app/api/auth/register-with-invitation/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
     const hashedPassword = await bcrypt.hash(password, 12)
 
     // Create user and family membership in a transaction
-    const result = await prisma.$transaction(async (tx: typeof prisma) => {
+    const result = await prisma.$transaction(async (tx) => {
       // Create user
       const user = await tx.user.create({
         data: {

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
     const hashedPassword = await bcrypt.hash(password, 12)
 
     // Create family and parent user in a transaction
-    const result = await prisma.$transaction(async (tx: typeof prisma) => {
+    const result = await prisma.$transaction(async (tx) => {
       // Create family
       const family = await tx.family.create({
         data: {

--- a/web/src/app/api/banking/approve/route.ts
+++ b/web/src/app/api/banking/approve/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
 
     if (approved) {
       // Approve banking request
-      await prisma.$transaction(async (tx: typeof prisma) => {
+      await prisma.$transaction(async (tx) => {
         // Update the transaction status
         await tx.pointTransaction.update({
           where: { id: transactionId },
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
 
     } else {
       // Deny banking request - return points to user
-      await prisma.$transaction(async (tx: typeof prisma) => {
+      await prisma.$transaction(async (tx) => {
         // Update the transaction status
         await tx.pointTransaction.update({
           where: { id: transactionId },

--- a/web/src/app/api/memberships/remove-child/route.ts
+++ b/web/src/app/api/memberships/remove-child/route.ts
@@ -54,7 +54,7 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Start transaction to clean up all child data
-    await prisma.$transaction(async (tx: typeof prisma) => {
+    await prisma.$transaction(async (tx) => {
       // 1. Delete chore submissions and approvals
       const submissions = await tx.choreSubmission.findMany({
         where: { userId: childId },

--- a/web/src/lib/prisma.ts
+++ b/web/src/lib/prisma.ts
@@ -1,33 +1,16 @@
-// Safe Prisma loader that avoids crashing builds when prisma is not generated
-let PrismaClientConstructor: any
-try {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	PrismaClientConstructor = require('@prisma/client').PrismaClient
-} catch {
-	PrismaClientConstructor = null
-}
-
-let Decimal: any
-try {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	Decimal = require('@prisma/client/runtime/library').Decimal
-} catch {
-	Decimal = class {}
-}
+import { PrismaClient, Prisma } from '@prisma/client'
 
 const globalForPrisma = globalThis as unknown as {
-	prisma: any
+  prisma: PrismaClient | undefined
 }
 
-let prismaInstance: any = undefined
-if (PrismaClientConstructor && process.env.DATABASE_URL) {
-	prismaInstance = globalForPrisma.prisma ?? new PrismaClientConstructor({
-		datasources: {
-			db: { url: process.env.DATABASE_URL }
-		}
-	})
-	if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prismaInstance
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
 }
 
-export const prisma = prismaInstance
+const Decimal = Prisma.Decimal
 export { Decimal } 


### PR DESCRIPTION
The application was failing to build and producing authentication errors due to an issue with Prisma client initialization. The client was configured to generate to a custom path, but the application code was attempting to import it from the default location using a fragile `try...catch` block. This caused the Prisma client to be undefined at build time, leading to numerous downstream errors.

This commit addresses the issue by:

1.  Removing the custom `output` path from `web/prisma/schema.prisma` to revert to the standard `node_modules/.prisma/client` location.
2.  Replacing the complex and error-prone client instantiation logic in `web/src/lib/prisma.ts` with a standard, modern singleton pattern.
3.  Fixing consequential TypeScript errors in several API routes and scripts that arose from the corrected Prisma types. This included updating `Decimal` type usage and removing incorrect type annotations on Prisma transaction callbacks.