### PR TITLE
Fix build: add isRequired to parent-mark chore include

### DIFF
--- a/web/src/app/api/chores/parent-mark/route.ts
+++ b/web/src/app/api/chores/parent-mark/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
       assignment = await prisma.choreAssignment.create({
         data: { choreId, userId: childId, familyId: chore.familyId, weekStart },
         include: {
-          chore: { select: { title: true, reward: true, points: true, familyId: true } },
+          chore: { select: { title: true, reward: true, points: true, familyId: true, isRequired: true } },
           family: { select: { pointsToMoneyRate: true } }
         }
       })


### PR DESCRIPTION
Adds isRequired to the chore include when creating a choreAssignment in parent-mark endpoint to satisfy TS type expectations introduced by deny logic changes.